### PR TITLE
New: Custom page sizes 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,9 @@ import NextLink from 'next/link'
 import queryString from 'query-string'
 import pickBy from 'lodash/pickBy'
 import isEmpty from 'lodash/isEmpty'
+import isInteger from 'lodash/isInteger'
+import every from 'lodash/every'
+import uniq from 'lodash/uniq'
 
 import List from './components/List'
 import Item from './components/Item'
@@ -73,7 +76,21 @@ const getPageNumbers = ({
   return pageNumbers
 }
 
-const Pagination = ({ total, theme }) => {
+export const getSizes = (customSizes) => {
+  const defaultSizes = [20, 40, 60, 80, 100]
+  // only if customSizes is an array & all values are valid
+  if(Array.isArray(customSizes) && every(customSizes, isInteger)){
+    const uniqSizes = uniq(customSizes).sort()
+    // if the evaluate array is empty, return default
+    // otherwise, return evaluated values
+    if(!uniqSizes.length) return defaultSizes
+    return uniqSizes
+  }
+  // default
+  return defaultSizes
+} 
+
+const Pagination = ({ total, theme, sizes }) => {
   const styles = theme || defaultTheme
   const router = useRouter()
   const [hasRouter, setHasRouter] = useState(false)
@@ -84,7 +101,9 @@ const Pagination = ({ total, theme }) => {
   if (!hasRouter) return null
   const query = pickBy({ ...(router.query || {}) }, (q) => !isEmpty(q))
   const currentPage = Number(query.page || 1)
-  const pageSize = Number(query.size || 20)
+  // default|custom => evaluated sizes
+  const cSizes = getSizes(sizes)
+  const pageSize = Number(query.size) || cSizes[0]
   const isLastPage = currentPage * pageSize >= total
   const pageNumbers = getPageNumbers({ currentPage, pageSize, total })
 
@@ -175,11 +194,7 @@ const Pagination = ({ total, theme }) => {
             router.push(url)
           }}
         >
-          <option>20</option>
-          <option>40</option>
-          <option>60</option>
-          <option>80</option>
-          <option>100</option>
+        { cSizes.map(size => <option key={size}>{size}</option>) }
         </Select>
         <button className={styles['next-pagination__submit']} type='submit'>
           Set page size

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -17,5 +17,7 @@ describe('Custom Sizes', () => {
   it('should return default sizes', () => {
     // will return defaults
     assert.deepStrictEqual(getSizes([]), [20,40,60,80,100])
+    assert.deepStrictEqual(getSizes(["", 10, 20]), [20,40,60,80,100])
+    assert.deepStrictEqual(getSizes([{}, {}]), [20,40,60,80,100])
   })
 })

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,4 +1,4 @@
-import { Pagination } from '.'
+import Pagination from '.'
 
 describe('Pagination', () => {
   it('is truthy', () => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,7 +1,21 @@
-import Pagination from '.'
+import Pagination, { getSizes} from '.'
+import assert from 'assert'
 
 describe('Pagination', () => {
   it('is truthy', () => {
     expect(Pagination).toBeTruthy()
+  })
+})
+
+// NOTE: [20,40,60,80,100] <= default sizes
+describe('Custom Sizes', () => {
+  it('should return an array', () => {
+    // second argument is the default value
+    assert.deepStrictEqual(getSizes(), [20,40,60,80,100])
+    assert.deepStrictEqual(getSizes([10,20,10]), [10,20])
+  })
+  it('should return default sizes', () => {
+    // will return defaults
+    assert.deepStrictEqual(getSizes([]), [20,40,60,80,100])
   })
 })


### PR DESCRIPTION
### What's new?

- Custom sizes 
- Added Unit Testing for ```getSizes``` 
- Fixed import _typo_ from existing .test.js file 

_Specification_
prop: ```sizes```
type: _array_
default: [20,40,60,80,100] 
description: The ```sizes``` prop is properly evaluated and check for uniqueness. It will return _default_ value if the passed prop is invalid and eliminate duplicate values and return the _sizes_  array in _ASC_ order
example cases:
received => returned
- [10,20,10] => [10,20]
- [10,10, ""] => ```default```
- [] => ```default```

**Snippet**
```
    <Pagination total={100} sizes={[10,15,20]} />
```

