### PR TITLE
refactor: SASS: Replace / with math.div

### DIFF
--- a/src/index.module.scss
+++ b/src/index.module.scss
@@ -3,8 +3,8 @@ $next-pagination-interative-color: #72256d;
 $next-pagination-spacing-vertical: 1em;
 $next-pagination-spacing-horizontal: 1em;
 
-$next-pagination-spacing-vertical-sm: $next-pagination-spacing-vertical / 2;
-$next-pagination-spacing-horizontal-sm: $next-pagination-spacing-horizontal / 2;
+$next-pagination-spacing-vertical-sm: $next-pagination-spacing-vertical * 0.5;
+$next-pagination-spacing-horizontal-sm: $next-pagination-spacing-horizontal * 0.5;
 
 $next-pagination-border-width: 1px;
 $next-pagination-border-radius: 4px;


### PR DESCRIPTION
Silences the following warnings and updates code as per recommendation at https://sass-lang.com/d/slash-div (redirects to https://sass-lang.com/documentation/breaking-changes/slash-div):

```
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($next-pagination-spacing-vertical, 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

  ╷
6 │ $next-pagination-spacing-vertical-sm: $next-pagination-spacing-vertical / 2;
  │                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
    components/next-pagination-spectrum/src/index.module.scss 6:39  root stylesheet

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($next-pagination-spacing-horizontal, 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

  ╷
7 │ $next-pagination-spacing-horizontal-sm: $next-pagination-spacing-horizontal / 2;
  │                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
    components/next-pagination-spectrum/src/index.module.scss 7:41  root stylesheet
```