### PR TITLE
ci: harden workflow permissions and pin actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,29 +6,33 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-permissions: read-all
+permissions: {}
 jobs:
   build:
     name: 🔨 Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: .nvmrc
           cache: npm
-      - run: npm ci
+      - run: npm ci --no-scripts
       - run: npm run build
   test:
     name: 🧪 Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: .nvmrc
           cache: npm
-      - run: npm ci
+      - run: npm ci --no-scripts
       - run: npm test
   lint:
     name: 🧹 Lint
@@ -37,15 +41,15 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: .nvmrc
           cache: npm
-      - run: npm ci
-      - uses: oxsecurity/megalinter/flavors/javascript@v7
+      - run: npm ci --no-scripts
+      - uses: oxsecurity/megalinter/flavors/javascript@8fbdead70d1409964ab3d5afa885e18ee85388bb  # v9.4.0
         env:
           VALIDATE_ALL_CODEBASE: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Set top-level `permissions: {}` (none) and grant minimum per-job scopes
- Pin all actions to commit SHAs with version comments: `checkout` v6.0.2, `setup-node` v6.4.0, `megalinter` v9.4.0
- Switch `npm ci` to `npm ci --no-scripts` in build/test/lint

## Test plan
- [ ] CI jobs (build, test, lint) pass under new permissions + `--no-scripts`
- [ ] Megalinter v9.4.0 runs with existing env vars
- [ ] No job needs scopes beyond what's granted

🤖 Generated with [Claude Code](https://claude.com/claude-code)